### PR TITLE
Bug fix: need more than 32 bits to store BCD version of a 32-bit bina…

### DIFF
--- a/src/memorymap.s
+++ b/src/memorymap.s
@@ -29,6 +29,7 @@ BIPPREV     .dword ?    ; Pointer to the previous bytein the current BASIC progr
 INDEX       .dword ?    ; A temporary pointer
 SCRATCH     .dword ?    ; A temporary scratch variable
 SCRATCH2    .dword ?    ; A temporary scratch variable
+            .word  ?	; Need a few more bits for BCD conversion
 STRPTR      .dword ?    ; A temporary pointer for strings
 CURLINE     .dword ?    ; Pointer to the current input line needing tokenization
 CURTOKLEN   .byte ?     ; Length of the text of the current token

--- a/src/strings.s
+++ b/src/strings.s
@@ -109,6 +109,7 @@ start_cnvt  ; Convert the binary number in ARGUMENT1 into a BCD
 
             STZ SCRATCH2        ; SCRATCH2 will be our BCD version of the number
             STZ SCRATCH2+2
+            STZ SCRATCH2+4
 
             LDX #31
             SED                 ; Yes, we're really using BCD mode
@@ -122,6 +123,9 @@ shift_loop  ASL ARGUMENT1       ; Shift ARGUMENT1 left one bit
             LDA SCRATCH2+2
             ADC SCRATCH2+2
             STA SCRATCH2+2
+            LDA SCRATCH2+4
+            ADC SCRATCH2+4
+            STA SCRATCH2+4
 
             DEX
             BPL shift_loop      ; Loop through all 32 bits of ARGUMENT1
@@ -146,7 +150,7 @@ wr_lead     STA [STRPTR],Y
             INY
 
             ; Skip over leading 0s
-            LDX #3
+            LDX #5
 
             ; Process first nybble
 ascii_loop  LDA SCRATCH2,X


### PR DESCRIPTION
…ry value.

Without this, any attempt to print values above 99M will be truncated (modulo 100M).