### PR TITLE
Itof via float copro

### DIFF
--- a/src/floats.s
+++ b/src/floats.s
@@ -460,6 +460,8 @@ s8_shift        CALL SHIFTDEC           ; Shift the decimal digit onto ARGUMENT1
                 
                 LDA @l M0_RESULT        ; And save it back to MARG3
                 STA MARG3
+                LDA @l M0_RESULT+2
+                STA MARG3+2
                 setas
 
 s8_drop         INY


### PR DESCRIPTION
This patch uses the 20:12 fixed-point to 32-bit float conversion mechanism in the fp coprocessor to implement ITOF. It is somewhat simpler and probably faster than the current implementation; on the other hand, it is specific to the C256Foenix (so it might make sense to keep the old implementation for other platforms, and use conditionals to choose the right implementation at assembly time).