### PR TITLE
Fix printing of 0.0: need to initialize pointer into TEMPSTRING, and …

### DIFF
--- a/src/floats.s
+++ b/src/floats.s
@@ -995,7 +995,7 @@ L_X1            .byte ?                     ; The binary exponent
 L_EXP           .byte ?                     ; The decimal exponent
                 .endv
  
-                CALL FARG1EQ0               ; If N is zero, output a zero and end.
+                CALL FARG1EQ0               ; If N is zero, output a space, a zero and end.
                 BCC chk_negative
 
                 TRACE "is_zero"
@@ -1003,6 +1003,10 @@ L_EXP           .byte ?                     ; The decimal exponent
                 CALL TEMPSTRING
 
                 setas
+                LDY #0
+                LDA #' '
+                STA [STRPTR],Y
+                INY
                 LDA #'0'                    ; Return a "0"
                 STA [STRPTR],Y
                 INY


### PR DESCRIPTION
…emit a blank to align with printing of other non-negative numbers.

Without this patch, printing the float value 0.0 would normally print garbage and occasionally crash into the monitor.

